### PR TITLE
Directorios con Espacios

### DIFF
--- a/src/lftp_mirror.py
+++ b/src/lftp_mirror.py
@@ -640,7 +640,7 @@ def mirror(args, log):
     with open('ftpscript', 'w') as script:
         lines = ('open {0}ftp://{1} {2}'.format(args.secure, args.site, port),
                  'user {0}'.format(user),
-                 'mirror {0} {1} {2}'.format(scp_args,
+                 'mirror {0} "{1}" "{2}"'.format(scp_args,
                                              local if args.reverse else remote,
                                              remote if args.reverse else local),
                  'exit')
@@ -677,15 +677,21 @@ def mirror(args, log):
 
 def parse_parms(*parms):
     """Parse parameters from script or config file to shell format."""
-    parameters = ("shell {0} {1} {2} {3} {4} {5} {6}".
+   parameters = ("shell {0} {1} {2} {3} {4} {5} {6}".
                   format(parms[0],
                          '-p {0}'.format(parms[1]) if parms[1] else '',
-                         parms[2],
-                         parms[3],
+                         parms[2].replace(" ","¤"),
+                         parms[3].replace(" ","¤"),
                          '-l {0}'.format(parms[4]) if parms[4] else '',
                          base64.b64decode(parms[5]),
                          parms[6]))
-    return parameters.split()
+
+   retParam =  parameters.split()
+
+   for i in range(len(retParam)):
+	   retParam[i] = retParam[i].replace("¤"," ")
+
+   return retParam 
 
 
 def main():


### PR DESCRIPTION
Con esta modificación podemos realizar la replicación de directorios que tengan espacios en su nombre del tipo "/home/user/Mis Documentos"
